### PR TITLE
コンテナイメージの取得先とマニフェストの修正

### DIFF
--- a/manifests/4.2/apache-deploy.yaml
+++ b/manifests/4.2/apache-deploy.yaml
@@ -17,6 +17,6 @@ spec:
     spec:
       containers:
       - name: apache-container
-        image: httpd:alpine
+        image: public.ecr.aws/docker/library/httpd:alpine
         ports:
         - containerPort: 80

--- a/manifests/4.4/apache-deploy-selfheal.yaml
+++ b/manifests/4.4/apache-deploy-selfheal.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: apache-container
-        image: httpd:alpine
+        image: public.ecr.aws/docker/library/httpd:alpine
         ports:
         - containerPort: 80
       tolerations:

--- a/manifests/4.5/apache.yaml
+++ b/manifests/4.5/apache.yaml
@@ -24,7 +24,7 @@ spec:
         app: httpd
     spec:
       containers:
-      - image: httpd:alpine
+      - image: public.ecr.aws/docker/library/httpd:alpine
         name: httpd
         ports:
         - containerPort: 80

--- a/manifests/4.5/ingress-path.yaml
+++ b/manifests/4.5/ingress-path.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ingress-path
   namespace: publish-app
 spec:
+  ingressClassName: nginx
   rules:
   - http:
       paths:

--- a/manifests/4.5/nginx.yaml
+++ b/manifests/4.5/nginx.yaml
@@ -24,7 +24,7 @@ spec:
         app: nginx
     spec:
       containers:
-      - image: nginx:alpine
+      - image: public.ecr.aws/docker/library/nginx:alpine
         name: nginx
         ports:
         - containerPort: 80

--- a/manifests/4.6/metrics-server/components.yaml
+++ b/manifests/4.6/metrics-server/components.yaml
@@ -36,11 +36,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes/metrics
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - pods
   - nodes
-  - nodes/stats
-  - namespaces
-  - configmaps
   verbs:
   - get
   - list
@@ -130,12 +133,12 @@ spec:
       containers:
       - args:
         - --cert-dir=/tmp
-        - --secure-port=443
+        - --secure-port=4443
         - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
         - --kubelet-insecure-tls
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -146,7 +149,7 @@ spec:
           periodSeconds: 10
         name: metrics-server
         ports:
-        - containerPort: 443
+        - containerPort: 4443
           name: https
           protocol: TCP
         readinessProbe:
@@ -162,6 +165,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1000

--- a/manifests/4.6/resource-consumer/resource-consumer.yaml
+++ b/manifests/4.6/resource-consumer/resource-consumer.yaml
@@ -7,7 +7,7 @@ metadata:
   name: resource-consumer
 spec:
   containers:
-  - image: gcr.io/k8s-staging-e2e-test-images/resource-consumer:1.10-linux-arm
+  - image: gcr.io/k8s-staging-e2e-test-images/resource-consumer:1.11-linux-arm64
     name: resource-consumer
     ports:
     - containerPort: 8080


### PR DESCRIPTION
主な修正は以下の通り。
- resource-consumer および nginx-ingress-controller のコンテナイメージを最新のものに変更
- ApacheとNginxのコンテナイメージの取得先をDocker HubからECR Public Galleryに変更
- Kubernetesのバージョンアップに伴い、Ingressのパラメータを修正